### PR TITLE
chore: update VSCode setting name for imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -145,7 +145,6 @@
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableMsBuildLoadProjectsOnDemand": false,
   "omnisharp.maxFindSymbolsItems": 3000,
-  "omnisharp.organizeImportsOnFormat": true,
   "omnisharp.useModernNet": true,
   // Remove these if you're happy with your terminal profiles.
   "terminal.integrated.defaultProfile.windows": "Git Bash",
@@ -165,5 +164,6 @@
       "icon": "terminal-powershell",
       "source": "PowerShell"
     }
-  }
+  },
+  "dotnet.formatting.organizeImportsOnFormat": true
 }


### PR DESCRIPTION
Updated VSCode settings to reflect new name for import-organization setting.