### PR TITLE
doc: update badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ Once a save chunk has been added to a parent save chunk, the parent save chunk c
 
 🐣 Package generated from a 🐤 Chickensoft Template — <https://chickensoft.games>
 
-[chickensoft-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/chickensoft_badge.svg
+[chickensoft-badge]: https://chickensoft.games/img/badges/chickensoft_badge.svg
 [chickensoft-website]: https://chickensoft.games
-[discord-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/discord_badge.svg
+[discord-badge]: https://chickensoft.games/img/badges/discord_badge.svg
 [discord]: https://discord.gg/gSjaPgMmYW
-[read-the-docs-badge]: https://raw.githubusercontent.com/chickensoft-games/chickensoft_site/main/static/img/badges/read_the_docs_badge.svg
+[read-the-docs-badge]: https://chickensoft.games/img/badges/read_the_docs_badge.svg
 [docs]: https://chickensoft.games/docs
 [line-coverage]: Chickensoft.SaveFileBuilder.Tests/badges/line_coverage.svg
 [branch-coverage]: Chickensoft.SaveFileBuilder.Tests/badges/branch_coverage.svg


### PR DESCRIPTION
Updated badge URLs in README to match the new Chickensoft site.