### PR TITLE
chore: remove outdated comment in workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         # Put the operating systems you want to run on here.
-        #
-        # You can change windows-2019 to windows-latest, but windows-2019
-        # was running in half the time. Try it out and see what works best.
         os: [ubuntu-latest]
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
Removed a comment in test workflow referencing the windows-2019 action runner, which is being deprecated and isn't used here.