### PR TITLE
chore: update SDKs

### DIFF
--- a/Chickensoft.SaveFileBuilder.Tests/Chickensoft.SaveFileBuilder.Tests.csproj
+++ b/Chickensoft.SaveFileBuilder.Tests/Chickensoft.SaveFileBuilder.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Godot.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "rollForward": "major",
-    "version": "7.0.404"
-    },
-    "msbuild-sdks": {
-      "Godot.NET.Sdk": "4.2.2"
-    }
+    "version": "8.0.410",
+    "rollForward": "latestMinor"
+  },
+  "msbuild-sdks": {
+    "Godot.NET.Sdk": "4.4.1"
+  }
 }


### PR DESCRIPTION
Updated global.json to latest .NET 8 and latest Godot (4.4.1). Updated test csproj to target net8.0.